### PR TITLE
(chore): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Owners will be requested for
+# review when someone opens a pull request.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @austinborn


### PR DESCRIPTION
### Description
Adds a CODEOWNERS file to automatically tag reviewers, which allows for more timely contribution.